### PR TITLE
[기능] 카카오 로그인을 수행해서 토큰으로 로그인 상태 관리를 구현했어요

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@eslint/js": "^9.10.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -4938,6 +4939,13 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@eslint/js": "^9.10.0",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router-dom';
 
 import MainLayout from '@/components/common/layouts/MainLayout';
 
+import AuthPage from '@/pages/Auth';
 import DetailPage from '@/pages/Detail';
 import InfluencerPage from '@/pages/Influencer';
 import MainPage from '@/pages/Main';
@@ -22,6 +23,8 @@ function App() {
           <Route path="/detail" element={<DetailPage />} />
           <Route path="/my" element={<MyPage />} />
         </Route>
+
+        <Route path="/auth" element={<AuthPage />} />
       </Routes>
     </>
   );

--- a/src/api/instance/index.ts
+++ b/src/api/instance/index.ts
@@ -1,0 +1,10 @@
+const PRODUCTION_URL = 'http://localhost:8080'; // 나중에 실제 서버 주소로 변경 예정
+const DEVELOPMENT_URL = 'http://localhost:8080';
+
+const BASE_URL = PRODUCTION_URL || DEVELOPMENT_URL;
+
+const getBaseUrl = (): string => {
+  return BASE_URL;
+};
+
+export default getBaseUrl;

--- a/src/components/common/layouts/Footer.tsx
+++ b/src/components/common/layouts/Footer.tsx
@@ -80,11 +80,12 @@ export default function Footer() {
 }
 
 const FooterContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  // display: flex;
+  // flex-direction: column;
+  // align-items: flex-start;
   background: #2f2f2f;
   width: 100%;
+  padding: 30px;
 `;
 
 const FooterSection = styled.div`

--- a/src/components/common/layouts/Header.tsx
+++ b/src/components/common/layouts/Header.tsx
@@ -7,6 +7,8 @@ import styled from 'styled-components';
 import LoginModal from '@/components/common/modals/LoginModal';
 import { Text } from '@/components/common/typography/Text';
 
+import Logo from "@/assets/images/Logo.svg";
+
 export default function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const location = useLocation();
@@ -27,7 +29,7 @@ export default function Header() {
   return (
     <HeaderContainer>
       <LogoContainer>
-        <Logo src="src/assets/images/Logo.svg" alt="인플레이스 로고" />
+        <LogoImage src={Logo} alt="인플레이스 로고" />
         <Text size="l" weight="bold" variant="mint">
           인 플레이스
         </Text>
@@ -75,7 +77,7 @@ const LogoContainer = styled.div`
   align-items: center;
 `;
 
-const Logo = styled.img`
+const LogoImage = styled.img`
   height: 40px;
   margin-right: 20px;
 `;

--- a/src/components/common/layouts/Header.tsx
+++ b/src/components/common/layouts/Header.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
+import Cookies from 'js-cookie';
 import styled from 'styled-components';
 
 import LoginModal from '@/components/common/modals/LoginModal';
@@ -8,9 +9,19 @@ import { Text } from '@/components/common/typography/Text';
 
 export default function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
 
-  const handleLoginToggle = () => {
-    setIsLoggedIn(!isLoggedIn);
+  useEffect(() => {
+    const accessToken = Cookies.get('access_token');
+    setIsLoggedIn(!!accessToken);
+  }, []);
+
+  const handleLogout = () => {
+    Cookies.remove('access_token');
+    Cookies.remove('refresh_token');
+    setIsLoggedIn(false);
+    navigate('/');
   };
 
   return (
@@ -29,7 +40,7 @@ export default function Header() {
                 마이페이지
               </Text>
             </NavItem>
-            <LoginButton onClick={handleLoginToggle}>로그아웃</LoginButton>
+            <LoginButton onClick={handleLogout}>로그아웃</LoginButton>
           </>
         ) : (
           <>
@@ -38,7 +49,9 @@ export default function Header() {
                 인플루언서
               </Text>
             </NavItem>
-            <LoginModal>{(openModal) => <LoginButton onClick={openModal}>로그인</LoginButton>}</LoginModal>
+            <LoginModal currentPath={location.pathname}>
+              {(openModal) => <LoginButton onClick={openModal}>로그인</LoginButton>}
+            </LoginModal>
           </>
         )}
       </Nav>

--- a/src/components/common/layouts/Header.tsx
+++ b/src/components/common/layouts/Header.tsx
@@ -60,16 +60,15 @@ export default function Header() {
     </HeaderContainer>
   );
 }
-export const HEADER_HEIGHT = 60;
+export const HEADER_HEIGHT = 80;
 
 const HeaderContainer = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 20px;
-  height: 60px;
-  background-color: #292929;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  height: 80px;
+  box-sizing: border-box;
 `;
 
 const LogoContainer = styled.div`

--- a/src/components/common/modals/LoginModal.tsx
+++ b/src/components/common/modals/LoginModal.tsx
@@ -7,6 +7,8 @@ import styled from 'styled-components';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import { Text } from '@/components/common/typography/Text';
 
+import getBaseUrl from '@/api/instance';
+
 type LoginModalProps = {
   children: (openModal: () => void) => React.ReactNode;
 };
@@ -17,22 +19,9 @@ export default function LoginModal({ children }: LoginModalProps) {
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
-  const handleKakaoLogin = async () => {
-    try {
-      const response = await fetch('/auth2/authorization/kakao', {
-        method: 'GET',
-        credentials: 'include',
-      });
-
-      if (response.ok) {
-        const redirectUrl = await response.text();
-        window.location.href = redirectUrl;
-      } else {
-        console.error('카카오 로그인 요청 실패');
-      }
-    } catch (error) {
-      console.error('카카오 로그인 요청 중 오류 발생:', error);
-    }
+  const handleKakaoLogin = () => {
+    const baseUrl = getBaseUrl();
+    window.location.href = `${baseUrl}/oauth2/authorization/kakao`;
   };
 
   if (!isOpen) {
@@ -43,7 +32,7 @@ export default function LoginModal({ children }: LoginModalProps) {
     <ModalOverlay>
       <ModalContainer>
         <CloseButton onClick={closeModal}>X</CloseButton>
-        <Logo src="src/assets/images/Logo.svg" alt="인플레이스 로고" />
+        <Logo src="/src/assets/images/Logo.svg" alt="인플레이스 로고" />
         <TitleWrapper>
           <Paragraph size="l" weight="bold">
             인 플레이스

--- a/src/components/common/modals/LoginModal.tsx
+++ b/src/components/common/modals/LoginModal.tsx
@@ -8,6 +8,7 @@ import { Paragraph } from '@/components/common/typography/Paragraph';
 import { Text } from '@/components/common/typography/Text';
 
 import getBaseUrl from '@/api/instance';
+import Logo from "@/assets/images/Logo.svg";
 
 type LoginModalProps = {
   children: (openModal: () => void) => React.ReactNode;
@@ -34,7 +35,7 @@ export default function LoginModal({ children, currentPath }: LoginModalProps) {
     <ModalOverlay>
       <ModalContainer>
         <CloseButton onClick={closeModal}>X</CloseButton>
-        <Logo src="/src/assets/images/Logo.svg" alt="인플레이스 로고" />
+        <LogoImage src={Logo} alt="인플레이스 로고" />
         <TitleWrapper>
           <Paragraph size="l" weight="bold">
             인 플레이스
@@ -85,7 +86,7 @@ const CloseButton = styled.button`
   cursor: pointer;
 `;
 
-const Logo = styled.img`
+const LogoImage = styled.img`
   position: absolute;
   top: 22%;
   left: 50%;

--- a/src/components/common/modals/LoginModal.tsx
+++ b/src/components/common/modals/LoginModal.tsx
@@ -11,9 +11,10 @@ import getBaseUrl from '@/api/instance';
 
 type LoginModalProps = {
   children: (openModal: () => void) => React.ReactNode;
+  currentPath: string;
 };
 
-export default function LoginModal({ children }: LoginModalProps) {
+export default function LoginModal({ children, currentPath }: LoginModalProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const openModal = () => setIsOpen(true);
@@ -21,6 +22,7 @@ export default function LoginModal({ children }: LoginModalProps) {
 
   const handleKakaoLogin = () => {
     const baseUrl = getBaseUrl();
+    localStorage.setItem('redirectPath', currentPath);
     window.location.href = `${baseUrl}/oauth2/authorization/kakao`;
   };
 

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function AuthPage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const redirectPath = localStorage.getItem('redirectPath') || '/';
+    localStorage.removeItem('redirectPath');
+
+    navigate(redirectPath);
+  }, [navigate]);
+
+  return null;
+}


### PR DESCRIPTION
### ✨ 작업 내용
 - [x] 로그인 성공 시 cookie로 받은 token으로 로그인 상태(isLoggedIn) 관리
 - [x] 로그인 성공 시, 로그인 이전 페이지로 리다이렉트시켜주기
---

### ✨ 참고 사항
- 백엔드 코드에서 쿠키에 토큰을 넣어 redirect할 주소를 response.sendRedirect("http://localhost:5173/auth");로 변경했습니다.
  - 서버 도메인(http://localhost:8080/auth)으로 리다이렉트하게 되면, 프론트 서버에서는 쿠키에 있는 access, refresh token으로 로그인 상태를 관리할 수 없다고 생각했기 때문입니다.
- 백엔드 코드의 CustonSuccessHandler.java 코드에서 `cookie.setHttpOnly(true);`를 주석처리 한 상태에서 진행하게 되었습니다.
  - 보안상, cookie.setHttpOnly(true); 속성이 설정된 쿠키는 클라이언트 단의 javascript에서 접근할 수 없어서, `const accessToken = Cookies.get('access_token');` 코드가 undefined를 반환했기 때문입니다.
---

### ⏰ 현재 버그
- 위 백엔드 코드를 수정하면 실행에는 문제가 없으나, 보안상의 문제가 걱정됩니다. 프론트에서 직접 accessToken을 관리하는 방법보다 서버만 `http://localhost:8080/auth`에서 직접 쿠키를 관리하도록 하고, 프론트는 해당 accessToken 유무 여부를 물어보는 api를 새로 만드는 방법을 고민하고 있습니다.
---

### ✏ Git Close
closes #10